### PR TITLE
Switch to using Redis stable

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -20,7 +20,7 @@ mktmpdir() {
 
 BUILD_DIR=$1
 CACHE_DIR=$2
-VERSION="3.0.4"
+VERSION="stable"
 REDIS_BUILD="$(mktmpdir redis)"
 INSTALL_DIR="$BUILD_DIR/.heroku/vendor/redis"
 PROFILE_PATH="$BUILD_DIR/.profile.d/redis.sh"


### PR DESCRIPTION
This addresses a security concern with the old version of Redis in the buildpack.

> Scripts and other automatic downloads can easily access the tarball of the latest Redis stable version at http://download.redis.io/redis-stable.tar.gz. The source code of the latest stable release is always browsable here, use the file src/version.h in order to extract the version in an automatic way.