### PR TITLE
Set the REDIS_URL and password configuration for Redis

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -46,6 +46,6 @@ fi
 PASSWORD=`openssl rand -hex 16`
 set-env PATH '/app/.heroku/vendor/redis/bin:$PATH'
 set-env REDIS_URL "redis://h:$PASSWORD@localhost:6379/"
-echo "redis-server </dev/null &> /dev/null &" >> $PROFILE_PATH
+echo "echo requirepass $PASSWORD | redis-server - &> /dev/null &" >> $PROFILE_PATH
 
 echo "Done" | indent

--- a/bin/compile
+++ b/bin/compile
@@ -43,7 +43,9 @@ else
 	cp -r $CACHE_DIR/redis_$VERSION/*  $INSTALL_DIR/
 fi
 
+PASSWORD=`openssl rand -hex 16`
 set-env PATH '/app/.heroku/vendor/redis/bin:$PATH'
+set-env REDIS_URL "redis://h:$PASSWORD@localhost:6379/"
 echo "redis-server </dev/null &> /dev/null &" >> $PROFILE_PATH
 
 echo "Done" | indent


### PR DESCRIPTION
This adds a `REDIS_URL` with the correct password in the same format as heroku-redis uses.