### PR TITLE
Add support for overriding the default Redis version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,14 @@ language: bash
 services:
   - docker
 env:
-  - STACK=cedar-14
-  - STACK=heroku-16
+  - STACK=cedar-14 REDIS_VERSION=3
+  - STACK=cedar-14 REDIS_VERSION=4
+  - STACK=heroku-16 REDIS_VERSION=3
+  - STACK=heroku-16 REDIS_VERSION=4
+  - STACK=heroku-16 REDIS_VERSION=5
+  # The default version (currently 3)
   - STACK=heroku-18
+  - STACK=heroku-18 REDIS_VERSION=4
+  - STACK=heroku-18 REDIS_VERSION=5.0.5
 script:
   - ./bin/test.sh "${STACK}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@ ARG RUNTIME_IMAGE
 # Use the build image variant (eg heroku-18-build) which include headers/build tools.
 FROM $BUILD_IMAGE as builder
 
+ARG REDIS_VERSION
+
 RUN mkdir -p /build /cache /env
+RUN [ -z "${REDIS_VERSION}" ] || echo "${REDIS_VERSION}" > /env/REDIS_VERSION
 COPY . /buildpack
 RUN /buildpack/bin/detect /build
 RUN /buildpack/bin/compile /build /cache /env

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ The first run of this buildpack will take a while as Redis is downloaded and
 compiled. Thereafter the compiled version will be cached. Redis will start locally
 and be available on `redis://127.0.0.1:6379` available in the `REDIS_URL` environment variable.
 
+By default Redis 3 is used, however you can specify a `REDIS_VERSION` in the `env` section of your
+[app.json](https://devcenter.heroku.com/articles/heroku-ci#environment-variables-env-key)
+to use a different major (e.g. "4" or "5") or exact (e.g. "5.0.5") version. This feature
+is experimental and subject to change.
+
 ## Releasing a new version
 
 Make sure you publish this buildpack in the buildpack registry

--- a/bin/compile
+++ b/bin/compile
@@ -20,10 +20,18 @@ mktmpdir() {
 
 BUILD_DIR=$1
 CACHE_DIR=$2
-VERSION="3.2.12"
 REDIS_BUILD="$(mktmpdir redis)"
 INSTALL_DIR="$BUILD_DIR/.heroku/vendor/redis"
 PROFILE_PATH="$BUILD_DIR/.profile.d/redis.sh"
+
+DEFAULT_VERSION="3"
+VERSION="${REDIS_VERSION:-$DEFAULT_VERSION}"
+
+case "${VERSION}" in
+  3) VERSION="3.2.12";;
+  4) VERSION="4.0.14";;
+  5) VERSION="5.0.5";;
+esac
 
 mkdir -p $INSTALL_DIR
 mkdir -p $(dirname $PROFILE_PATH)
@@ -32,7 +40,7 @@ mkdir -p $CACHE_DIR
 if [ ! -d $CACHE_DIR/redis_$VERSION ]; then
 	echo "Fetching and installing redis" | indent
 	cd $REDIS_BUILD
-	curl -OL "http://download.redis.io/releases/redis-$VERSION.tar.gz"
+	curl -OLf "http://download.redis.io/releases/redis-$VERSION.tar.gz"
 	tar zxvf "redis-$VERSION.tar.gz"
 	cd "redis-$VERSION"
 	make

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -22,6 +22,7 @@ echo "Building buildpack on stack ${STACK}..."
 docker build \
     --build-arg "BUILD_IMAGE=${BUILD_IMAGE}" \
     --build-arg "RUNTIME_IMAGE=${RUNTIME_IMAGE}" \
+    ${REDIS_VERSION:+--build-arg "REDIS_VERSION=${REDIS_VERSION}"} \
     -t "${OUTPUT_IMAGE}" \
     .
 


### PR DESCRIPTION
Users can now set `REDIS_VERSION` via the `env` section of their `app.json` to customise the Redis version used in CI, similar to what's supported for `heroku-buildpack-ci-postgresql` already.

At a later point we will likely change the default version from 3 to 4 too, however for now it's safer to leave that at the existing version.

Fixes [W-6167563](https://gus.my.salesforce.com/a07B0000006toMRIAY).