### PR TITLE
Load REDIS_VERSION from ENV_DIR and not the environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,16 @@ services:
 env:
   - STACK=cedar-14 REDIS_VERSION=3
   - STACK=cedar-14 REDIS_VERSION=4
+  - STACK=cedar-14 REDIS_VERSION=5
   - STACK=heroku-16 REDIS_VERSION=3
   - STACK=heroku-16 REDIS_VERSION=4
   - STACK=heroku-16 REDIS_VERSION=5
-  # The default version (currently 3)
-  - STACK=heroku-18
+  - STACK=heroku-18 REDIS_VERSION=3
   - STACK=heroku-18 REDIS_VERSION=4
+  - STACK=heroku-18 REDIS_VERSION=5
+  # The default version.
+  - STACK=heroku-18
+  # An exact point release version.
   - STACK=heroku-18 REDIS_VERSION=5.0.5
 script:
   - ./bin/test.sh "${STACK}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,14 @@
-ARG BUILD_IMAGE
-ARG RUNTIME_IMAGE
-
-# Use the build image variant (eg heroku-18-build) which include headers/build tools.
-FROM $BUILD_IMAGE as builder
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
 
 ARG REDIS_VERSION
 
-RUN mkdir -p /build /cache /env
+RUN mkdir -p /app /cache /env
 RUN [ -z "${REDIS_VERSION}" ] || echo "${REDIS_VERSION}" > /env/REDIS_VERSION
 COPY . /buildpack
 # Sanitize the environment seen by the buildpack, to prevent reliance on
 # environment variables that won't be present when it's run by Heroku CI.
-RUN env -i PATH=$PATH HOME=$HOME /buildpack/bin/detect /build
-RUN env -i PATH=$PATH HOME=$HOME /buildpack/bin/compile /build /cache /env
+RUN env -i PATH=$PATH HOME=$HOME /buildpack/bin/detect /app
+RUN env -i PATH=$PATH HOME=$HOME /buildpack/bin/compile /app /cache /env
 
-# Use the standard stack image for testing, to catch missing runtime dependencies.
-FROM $RUNTIME_IMAGE
-
-COPY --from=builder /build /app
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,10 @@ ARG REDIS_VERSION
 RUN mkdir -p /build /cache /env
 RUN [ -z "${REDIS_VERSION}" ] || echo "${REDIS_VERSION}" > /env/REDIS_VERSION
 COPY . /buildpack
-RUN /buildpack/bin/detect /build
-RUN /buildpack/bin/compile /build /cache /env
+# Sanitize the environment seen by the buildpack, to prevent reliance on
+# environment variables that won't be present when it's run by Heroku CI.
+RUN env -i PATH=$PATH HOME=$HOME /buildpack/bin/detect /build
+RUN env -i PATH=$PATH HOME=$HOME /buildpack/bin/compile /build /cache /env
 
 # Use the standard stack image for testing, to catch missing runtime dependencies.
 FROM $RUNTIME_IMAGE

--- a/bin/compile
+++ b/bin/compile
@@ -20,12 +20,17 @@ mktmpdir() {
 
 BUILD_DIR=$1
 CACHE_DIR=$2
+ENV_DIR=$3
 REDIS_BUILD="$(mktmpdir redis)"
 INSTALL_DIR="$BUILD_DIR/.heroku/vendor/redis"
 PROFILE_PATH="$BUILD_DIR/.profile.d/redis.sh"
 
 DEFAULT_VERSION="3"
-VERSION="${REDIS_VERSION:-$DEFAULT_VERSION}"
+if [ -f "${ENV_DIR}/REDIS_VERSION" ]; then
+  VERSION="$(cat ${ENV_DIR}/REDIS_VERSION)"
+else
+  VERSION="${DEFAULT_VERSION}"
+fi
 
 case "${VERSION}" in
   3) VERSION="3.2.12";;

--- a/bin/compile
+++ b/bin/compile
@@ -63,4 +63,4 @@ set-env PATH '/app/.heroku/vendor/redis/bin:$PATH'
 set-env REDIS_URL "redis://h:$PASSWORD@localhost:6379/"
 echo "echo requirepass $PASSWORD | redis-server - &> /dev/null &" >> $PROFILE_PATH
 
-echo "-----> redis done"
+echo "-----> Redis done"

--- a/bin/compile
+++ b/bin/compile
@@ -38,12 +38,14 @@ case "${VERSION}" in
   5) VERSION="5.0.5";;
 esac
 
+echo "Using redis version: ${VERSION}" | indent
+
 mkdir -p $INSTALL_DIR
 mkdir -p $(dirname $PROFILE_PATH)
 mkdir -p $CACHE_DIR
 
 if [ ! -d $CACHE_DIR/redis_$VERSION ]; then
-	echo "Fetching and installing redis" | indent
+	echo "-----> Downloading and installing redis into slug"
 	cd $REDIS_BUILD
 	curl -OLf "http://download.redis.io/releases/redis-$VERSION.tar.gz"
 	tar zxvf "redis-$VERSION.tar.gz"
@@ -52,7 +54,7 @@ if [ ! -d $CACHE_DIR/redis_$VERSION ]; then
 	make PREFIX=$CACHE_DIR/redis_$VERSION/ install
 	cp -r $CACHE_DIR/redis_$VERSION/* $INSTALL_DIR/
 else
-	echo "Installing redis from cache" | indent
+	echo "-----> Fetching redis from cache into slug"
 	cp -r $CACHE_DIR/redis_$VERSION/*  $INSTALL_DIR/
 fi
 
@@ -61,4 +63,4 @@ set-env PATH '/app/.heroku/vendor/redis/bin:$PATH'
 set-env REDIS_URL "redis://h:$PASSWORD@localhost:6379/"
 echo "echo requirepass $PASSWORD | redis-server - &> /dev/null &" >> $PROFILE_PATH
 
-echo "Done" | indent
+echo "-----> redis done"

--- a/bin/detect
+++ b/bin/detect
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
-echo "redis"
+echo "Redis"

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -26,12 +26,12 @@ docker build \
     -t "${OUTPUT_IMAGE}" \
     .
 
-echo "Checking redis-server responds to ping command..."
+echo "Checking redis-server presence and version..."
 
 # Redis <4 does not support connection URLs so REDIS_URL has to be parsed:
 # https://stackoverflow.com/questions/38271281/can-i-use-redis-cli-with-a-connection-url
 REDIS_CONNECTION_ARGS="\$(echo \${REDIS_URL} | sed 's_redis://h:\(.*\)@\(.*\):\(.*\)/_-h \2 -p \3 -a \1_')"
-TEST_COMMAND="source .profile.d/redis.sh && redis-cli ${REDIS_CONNECTION_ARGS} ping"
+TEST_COMMAND="source .profile.d/redis.sh && redis-cli ${REDIS_CONNECTION_ARGS} info | grep redis_version:${REDIS_VERSION:-}"
 docker run --rm -it "${OUTPUT_IMAGE}" bash -c "${TEST_COMMAND}"
 
 echo "Success!"

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -6,13 +6,10 @@ set -euo pipefail
 
 STACK="${1}"
 
-# Converts eg "heroku-18" -> "heroku/heroku:18".
-RUNTIME_IMAGE="heroku/${STACK/-/:}"
-
 if [[ "${STACK}" == "cedar-14" ]]; then
-    BUILD_IMAGE="${RUNTIME_IMAGE}"
+    BASE_IMAGE="heroku/${STACK/-/:}"
 else
-    BUILD_IMAGE="${RUNTIME_IMAGE}-build"
+    BASE_IMAGE="heroku/${STACK/-/:}-build"
 fi
 
 OUTPUT_IMAGE="redis-test-${STACK}"
@@ -20,8 +17,7 @@ OUTPUT_IMAGE="redis-test-${STACK}"
 echo "Building buildpack on stack ${STACK}..."
 
 docker build \
-    --build-arg "BUILD_IMAGE=${BUILD_IMAGE}" \
-    --build-arg "RUNTIME_IMAGE=${RUNTIME_IMAGE}" \
+    --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
     ${REDIS_VERSION:+--build-arg "REDIS_VERSION=${REDIS_VERSION}"} \
     -t "${OUTPUT_IMAGE}" \
     .

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -31,7 +31,7 @@ echo "Checking redis-server presence and version..."
 # Redis <4 does not support connection URLs so REDIS_URL has to be parsed:
 # https://stackoverflow.com/questions/38271281/can-i-use-redis-cli-with-a-connection-url
 REDIS_CONNECTION_ARGS="\$(echo \${REDIS_URL} | sed 's_redis://h:\(.*\)@\(.*\):\(.*\)/_-h \2 -p \3 -a \1_')"
-TEST_COMMAND="source .profile.d/redis.sh && redis-cli ${REDIS_CONNECTION_ARGS} info | grep redis_version:${REDIS_VERSION:-}"
+TEST_COMMAND="source .profile.d/redis.sh && sleep 1 && redis-cli ${REDIS_CONNECTION_ARGS} info | grep redis_version:${REDIS_VERSION:-}"
 docker run --rm -it "${OUTPUT_IMAGE}" bash -c "${TEST_COMMAND}"
 
 echo "Success!"


### PR DESCRIPTION
Since the buildpack API doesn't populate the environment automatically, we need to do so ourselves (follow up to #11):
https://devcenter.heroku.com/articles/buildpack-api#bin-compile

This follows the approach used by `heroku-buildpack-ci-postgresql`:
https://github.com/heroku/heroku-buildpack-ci-postgresql/blob/54c6d39bf997ebb612f7db07aab98cde1c5777c6/bin/compile#L22-L26

Also performs some compile output and CI-related cleanup.

See commits for details.

Fixes [W-6167563](https://gus.my.salesforce.com/a07B0000006toMRIAY).