### PR TITLE
use v4 for DEFAULT_VERSION

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -25,7 +25,7 @@ REDIS_BUILD="$(mktmpdir redis)"
 INSTALL_DIR="$BUILD_DIR/.heroku/vendor/redis"
 PROFILE_PATH="$BUILD_DIR/.profile.d/redis.sh"
 
-DEFAULT_VERSION="3"
+DEFAULT_VERSION="4"
 if [ -f "${ENV_DIR}/REDIS_VERSION" ]; then
   VERSION="$(cat ${ENV_DIR}/REDIS_VERSION)"
 else


### PR DESCRIPTION
We default to using Redis 4 for Heroku Redis:  https://devcenter.heroku.com/changelog-items/1643

This PR adjusts the in-dyno version for Heroku CI to also use version 4. Users can still override this with `REDIS_VERSION=3` or `REDIS_VERSION=5` in their `app.json`.