### PR TITLE
bump the patch version of redis 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ env:
   # The default version.
   - STACK=heroku-18
   # An exact point release version.
-  - STACK=heroku-18 REDIS_VERSION=5.0.5
+  - STACK=heroku-18 REDIS_VERSION=5.0.6
 script:
   - ./bin/test.sh "${STACK}"

--- a/bin/compile
+++ b/bin/compile
@@ -35,7 +35,7 @@ fi
 case "${VERSION}" in
   3) VERSION="3.2.12";;
   4) VERSION="4.0.14";;
-  5) VERSION="5.0.5";;
+  5) VERSION="5.0.6";;
 esac
 
 echo "Using redis version: ${VERSION}" | indent


### PR DESCRIPTION
This PR bumps the installed version of redis 5 from 5.0.5 to 5.0.6, which was released on 2019-09-25