### PR TITLE
Drop redis 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,10 @@ language: bash
 services:
   - docker
 env:
-  - STACK=cedar-14 REDIS_VERSION=3
   - STACK=cedar-14 REDIS_VERSION=4
   - STACK=cedar-14 REDIS_VERSION=5
-  - STACK=heroku-16 REDIS_VERSION=3
   - STACK=heroku-16 REDIS_VERSION=4
   - STACK=heroku-16 REDIS_VERSION=5
-  - STACK=heroku-18 REDIS_VERSION=3
   - STACK=heroku-18 REDIS_VERSION=4
   - STACK=heroku-18 REDIS_VERSION=5
   # The default version.

--- a/bin/compile
+++ b/bin/compile
@@ -33,7 +33,6 @@ else
 fi
 
 case "${VERSION}" in
-  3) VERSION="3.2.12";;
   4) VERSION="4.0.14";;
   5) VERSION="5.0.5";;
 esac


### PR DESCRIPTION
This PR drops support for redis 3.2 in heroku-buildpack-ci-redis.

Redis 3.2 support was dropped when [redis 5 went into beta](https://devcenter.heroku.com/changelog-items/1644)