### PR TITLE
Make 5 the default redis version

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -25,7 +25,7 @@ REDIS_BUILD="$(mktmpdir redis)"
 INSTALL_DIR="$BUILD_DIR/.heroku/vendor/redis"
 PROFILE_PATH="$BUILD_DIR/.profile.d/redis.sh"
 
-DEFAULT_VERSION="4"
+DEFAULT_VERSION="5"
 if [ -f "${ENV_DIR}/REDIS_VERSION" ]; then
   VERSION="$(cat ${ENV_DIR}/REDIS_VERSION)"
 else


### PR DESCRIPTION
This PR makes redis 5 the default version of redis. This is in support of making Redis 5 GA