### PR TITLE
Bring in-dyno redis in line with postgres

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -60,14 +60,16 @@ else
 fi
 
 PASSWORD=`openssl rand -hex 16`
+export REDIS_URL="redis://h:$PASSWORD@localhost:6379/"
 set-env PATH '/app/.indyno/vendor/redis/bin:$PATH'
-set-env REDIS_URL "redis://h:$PASSWORD@localhost:6379/"
+set-env REDIS_URL "$REDIS_URL"
+echo "export REDIS_URL=$REDIS_URL" >> $BUILDPACK_DIR/export
 echo "echo requirepass $PASSWORD | redis-server - &> /dev/null &" >> $PROFILE_PATH
 
 # ensure the redis-server is started during CI runs as the buildpack runner will terminate redis-server between buildpacks and .profile.d is too late
 cat<<EOF > $BUILDPACK_DIR/background
 PATH=$HOME/.indyno/vendor/redis/bin:$PATH
-export REDIS_URL="redis://h:$PASSWORD@localhost:6379/"
+export REDIS_URL="$REDIS_URL"
 echo requirepass $PASSWORD | redis-server - &> /dev/null &
 EOF
 

--- a/bin/compile
+++ b/bin/compile
@@ -59,9 +59,9 @@ else
 	cp -r $CACHE_DIR/redis_$VERSION/*  $INSTALL_DIR/
 fi
 
+set-env PATH '/app/.indyno/vendor/redis/bin:$PATH'
 PASSWORD=`openssl rand -hex 16`
 export REDIS_URL="redis://h:$PASSWORD@localhost:6379/"
-set-env PATH '/app/.indyno/vendor/redis/bin:$PATH'
 set-env REDIS_URL "$REDIS_URL"
 echo "export REDIS_URL=$REDIS_URL" >> $BUILDPACK_DIR/export
 echo "echo requirepass $PASSWORD | redis-server - &> /dev/null &" >> $PROFILE_PATH

--- a/bin/compile
+++ b/bin/compile
@@ -21,6 +21,7 @@ mktmpdir() {
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
+BUILDPACK_DIR="$(dirname $(dirname $0))"
 REDIS_BUILD="$(mktmpdir redis)"
 INSTALL_DIR="$BUILD_DIR/.indyno/vendor/redis"
 PROFILE_PATH="$BUILD_DIR/.profile.d/redis.sh"
@@ -62,5 +63,12 @@ PASSWORD=`openssl rand -hex 16`
 set-env PATH '/app/.indyno/vendor/redis/bin:$PATH'
 set-env REDIS_URL "redis://h:$PASSWORD@localhost:6379/"
 echo "echo requirepass $PASSWORD | redis-server - &> /dev/null &" >> $PROFILE_PATH
+
+# ensure the redis-server is started during CI runs as the buildpack runner will terminate redis-server between buildpacks and .profile.d is too late
+cat<<EOF > $BUILDPACK_DIR/background
+PATH=$HOME/.indyno/vendor/redis/bin:$PATH
+export REDIS_URL="redis://h:$PASSWORD@localhost:6379/"
+echo requirepass $PASSWORD | redis-server - &> /dev/null &
+EOF
 
 echo "-----> Redis done"


### PR DESCRIPTION
There are now some languages that are relying on redis to be up and the `REDIS_URL` to be available during build time. The [postgres in-dyno db](https://github.com/heroku/heroku-buildpack-ci-postgresql/blob/master/bin/compile) as a few things to handle this that I've brought to the redis in-dyno buildpack. Mainly the `background` file is used to start the redis-server before each buildpack's compile is executed. I also went ahead and wrote the `REDIS_URL` to `export` to align with the postgres version.