### PR TITLE
Removing connection string trailing slash

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -65,7 +65,7 @@ fi
 
 set-env PATH '/app/.indyno/vendor/redis/bin:$PATH'
 PASSWORD=`openssl rand -hex 16`
-export REDIS_URL="redis://h:$PASSWORD@localhost:6379/"
+export REDIS_URL="redis://h:$PASSWORD@localhost:6379"
 set-env REDIS_URL "$REDIS_URL"
 echo "export REDIS_URL=$REDIS_URL" >> $BUILDPACK_DIR/export
 echo "echo requirepass $PASSWORD | redis-server - &> /dev/null &" >> $PROFILE_PATH


### PR DESCRIPTION
Had a customer ticket saying the `REDIS_URL` trailing slash was causing them some config issues.  

They worked around the issue, but thought we should remove it to be in-line with the standard add-on versions connection string.

Hope that's ok.