### PR TITLE
Remove Heroku-16 from CI test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              stack: [heroku-16, heroku-18, heroku-20]
+              stack: [heroku-18, heroku-20]
               redis_version: ["3", "4", "5", "6"]
       # The default version.
       - test:


### PR DESCRIPTION
Since it's no longer possible to build with this stack on the Heroku platform, as the build system for it no longer exists.

See:
https://help.heroku.com/0S5P41DC/heroku-16-end-of-life-faq

Fixes #25.