### PR TITLE
Add Heroku-22 to the Circle CI test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,4 @@
 version: 2.1
-orbs:
-  docker: circleci/docker@1.5.0
 jobs:
   test:
     parameters:
@@ -9,13 +7,13 @@ jobs:
       redis_version:
         type: string
     docker:
-      - image: cimg/base:2020.01
+      - image: cimg/base:stable
     environment:
       STACK: << parameters.stack >>
       REDIS_VERSION: << parameters.redis_version >>
     steps:
       - setup_remote_docker:
-          docker_layer_caching: true
+          version: 20.10.11
       - checkout
       - run:
           name: "Running test"
@@ -27,7 +25,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              stack: [heroku-18, heroku-20]
+              stack: [heroku-18, heroku-20, heroku-22]
               redis_version: ["3", "4", "5", "6"]
       # The default version.
       - test:

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -5,13 +5,7 @@ set -euo pipefail
 [ $# -eq 1 ] || { echo "Usage: $0 STACK"; exit 1; }
 
 STACK="${1}"
-
-if [[ "${STACK}" == "cedar-14" ]]; then
-    BASE_IMAGE="heroku/${STACK/-/:}"
-else
-    BASE_IMAGE="heroku/${STACK/-/:}-build"
-fi
-
+BASE_IMAGE="heroku/${STACK/-/:}-build"
 OUTPUT_IMAGE="redis-test-${STACK}"
 
 echo "Building buildpack on stack ${STACK}..."


### PR DESCRIPTION
The Docker version used by the Circle CI remote Docker feature had to be bumped to prevent blocked syscall related errors:
`curl: (6) getaddrinfo() thread failed to start`

In addition:
- The Docker orb has been removed, since it was unused.
- Docker layer caching has been removed, since it didn't actually improve the CI end to end times.
- The Circle CI base image has been bumped to the newer `stable` tag.
- A Cedar-14 test script remnant has been removed.

GUS-W-10346688.