### PR TITLE
Use HTTPS to download Redis source

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -52,7 +52,7 @@ if [ ! -d "${CACHED_REDIS_DIR}" ]; then
 	echo "-----> Downloading and installing redis into slug"
 	rm -rf "${CACHE_DIR}"/redis_*
 	cd $REDIS_BUILD
-	curl -OLf "http://download.redis.io/releases/redis-$VERSION.tar.gz"
+	curl -OLf "https://download.redis.io/releases/redis-$VERSION.tar.gz"
 	tar zxvf "redis-$VERSION.tar.gz"
 	cd "redis-$VERSION"
 	make


### PR DESCRIPTION
Since https://download.redis.io is now available over HTTPS (it wasn't previously).