### PR TITLE
Update default version aliases to latest minor/patch versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,4 +36,4 @@ workflows:
       # An exact point release version.
       - test:
           stack: heroku-20
-          redis_version: "6.0.9"
+          redis_version: "6.0.16"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and be available on `redis://127.0.0.1:6379` available in the `REDIS_URL` enviro
 
 By default Redis 6 is used, however you can specify a `REDIS_VERSION` in the `env` section of your
 [app.json](https://devcenter.heroku.com/articles/heroku-ci#environment-variables-env-key)
-to use a different major (e.g. "4" or "5") or exact (e.g. "5.0.5") version. This feature
+to use a different major (e.g. "4" or "5") or exact (e.g. "6.0.16") version. This feature
 is experimental and subject to change.
 
 ## Releasing a new version

--- a/bin/compile
+++ b/bin/compile
@@ -34,10 +34,10 @@ else
 fi
 
 case "${VERSION}" in
-  3) VERSION="3.2.12";;
+  3) VERSION="3.2.13";;
   4) VERSION="4.0.14";;
-  5) VERSION="5.0.6";;
-  6) VERSION="6.0.9";;
+  5) VERSION="5.0.14";;
+  6) VERSION="6.2.7";;
 esac
 
 echo "Using redis version: ${VERSION}" | indent


### PR DESCRIPTION
Context...
Users of the buildpack can either:
- not specify a Redis version at all (in which case `6` is used for new apps, or the previously used version for existing apps)
- specify a major Redis version (such as `6` or `4`)
- specify an exact Redis version (such as `6.0.16`)
---

The current major version aliases are slightly outdated, so this PR updates them to the latest minor/patch versions to ensure CI is using the same versions as provisioned by the Heroku Redis addon.

In addition, the hope is that the newer 5.x version will fix the compile errors seen under Heroku-22 in #27.

The alias version changes are as follows:
- `3`: `3.2.12` -> `3.2.13`
- `5`: `5.0.6` -> `5.0.14`
- `6`: `6.0.9` -> `6.2.7`

This also means the default CI Redis version for new apps that don't specify a Redis version is now 6.2.x instead of 6.0.x - which matches the default for Heroku Redis:
https://devcenter.heroku.com/articles/heroku-redis#version-support-and-legacy-infrastructure

GUS-W-10346688.