### PR TITLE
GA redis 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The first run of this buildpack will take a while as Redis is downloaded and
 compiled. Thereafter the compiled version will be cached. Redis will start locally
 and be available on `redis://127.0.0.1:6379` available in the `REDIS_URL` environment variable.
 
-By default Redis 6 is used, however you can specify a `REDIS_VERSION` in the `env` section of your
+By default Redis 7 is used, however you can specify a `REDIS_VERSION` in the `env` section of your
 [app.json](https://devcenter.heroku.com/articles/heroku-ci#environment-variables-env-key)
 to use a different major (e.g. "4" or "5") or exact (e.g. "6.0.16") version. This feature
 is experimental and subject to change.

--- a/bin/compile
+++ b/bin/compile
@@ -26,7 +26,7 @@ REDIS_BUILD="$(mktmpdir redis)"
 INSTALL_DIR="$BUILD_DIR/.indyno/vendor/redis"
 PROFILE_PATH="$BUILD_DIR/.profile.d/redis.sh"
 
-DEFAULT_VERSION="6"
+DEFAULT_VERSION="7"
 if [ -f "${ENV_DIR}/REDIS_VERSION" ]; then
   VERSION="$(cat ${ENV_DIR}/REDIS_VERSION)"
 else
@@ -68,7 +68,7 @@ set-env PATH '/app/.indyno/vendor/redis/bin:$PATH'
 PASSWORD=`openssl rand -hex 16`
 
 # placeholder username h was added for compatibility with old Redis clients (https://devcenter.heroku.com/changelog-items/1932) and is incompatible with Redis 6 AUTH
-if [[ "${VERSION}" == 6.* ]]; then
+if [[ "${VERSION}" > 5.* ]]; then
 	export REDIS_URL="redis://:$PASSWORD@localhost:6379/"
 else
 	export REDIS_URL="redis://h:$PASSWORD@localhost:6379/"


### PR DESCRIPTION
This PR sets Redis 7 as default now that it has been GA'ed https://devcenter.heroku.com/changelog-items/2550 and fixes a minor bug with the h username to include v7