### PR TITLE
Fix version detection and comparison

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         stack: [heroku-18, heroku-20, heroku-22]
-        redis_version: ["", "4", "5", "6", "6.0.17", "7"]
+        redis_version: ["", "4", "5", "6", "6.2", "7", "7.0", "7.0.11"]
     runs-on: ubuntu-latest
 
     steps:

--- a/bin/compile
+++ b/bin/compile
@@ -37,8 +37,8 @@ case "${VERSION}" in
   3) VERSION="3.2.13";;
   4) VERSION="4.0.14";;
   5) VERSION="5.0.14";;
-  6) VERSION="6.2.11";;
-  7) VERSION="7.0.9";;
+  6|6.2) VERSION="6.2.12";;
+  7|7.0) VERSION="7.0.11";;
 esac
 
 echo "Using redis version: ${VERSION}" | indent
@@ -68,10 +68,10 @@ set-env PATH '/app/.indyno/vendor/redis/bin:$PATH'
 PASSWORD=`openssl rand -hex 16`
 
 # placeholder username h was added for compatibility with old Redis clients (https://devcenter.heroku.com/changelog-items/1932) and is incompatible with Redis 6 AUTH
-if [[ "${VERSION}" > 5.* ]]; then
-	export REDIS_URL="redis://:$PASSWORD@localhost:6379/"
-else
+if [[ "${VERSION}" < 6 ]]; then
 	export REDIS_URL="redis://h:$PASSWORD@localhost:6379/"
+else
+	export REDIS_URL="redis://:$PASSWORD@localhost:6379/"
 fi
 
 set-env REDIS_URL "$REDIS_URL"

--- a/bin/compile
+++ b/bin/compile
@@ -68,7 +68,7 @@ set-env PATH '/app/.indyno/vendor/redis/bin:$PATH'
 PASSWORD=`openssl rand -hex 16`
 
 # placeholder username h was added for compatibility with old Redis clients (https://devcenter.heroku.com/changelog-items/1932) and is incompatible with Redis 6 AUTH
-if [[ "${VERSION}" < 6 ]]; then
+if dpkg --compare-versions "$VERSION" "lt" 6; then
 	export REDIS_URL="redis://h:$PASSWORD@localhost:6379/"
 else
 	export REDIS_URL="redis://:$PASSWORD@localhost:6379/"


### PR DESCRIPTION
This PR fixes a couple issues:


**Regarding version detection/matching**, our docs suggest using `REDIS_VERSION = 7.0` to get Redis 7.0. This doesn't match with the existing case, which results in the version being set to `7.0` and the binary download failing.

I extended the case to detect "6.2" and "7.0". I didn't include older versions (6.0, 5.0, 4.0...) back in this change, as those are already deprecated in the Heroku Platform and that would change old behavior.


This PR also fixes the version comparison to not include the `h` username for Redis 6 or higher.

Lastly, I'm using the opportunity to point to the latest minor versions for both the stable versions 6.2 and 7.0.