### PR TITLE
feat: overhaul - add tls, version support

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -7,16 +7,18 @@ jobs:
     strategy:
       matrix:
         stack: [heroku-20, heroku-22, heroku-24]
-        redis_version: ["", "4", "5", "6", "6.2", "7", "7.0", "7.0.11"]
+        tls: ["", "true"]
+        redis_version: ["", "6.2", "7", "7.0", "7.0.11"]
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-    - name: Run Test
-      run: ./bin/test.sh ${{ matrix.stack }}
-      env:
-        REDIS_VERSION: ${{ matrix.redis_version }}
+      - name: Run Test
+        run: ./bin/test.sh ${{ matrix.stack }}
+        env:
+          REDIS_VERSION: ${{ matrix.redis_version }}
+          REDIS_CI_TLS: ${{ matrix.tls }}
 
   # dummy job to wait and block merge until all jobs have completed
   done:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,11 @@ FROM $BASE_IMAGE
 USER root
 
 ARG REDIS_VERSION
+ARG REDIS_CI_TLS
 
 RUN mkdir -p /app /cache /env
 RUN [ -z "${REDIS_VERSION}" ] || echo "${REDIS_VERSION}" > /env/REDIS_VERSION
+RUN [ -z "${REDIS_CI_TLS}" ] || echo "${REDIS_CI_TLS}" > /env/REDIS_CI_TLS
 COPY . /buildpack
 # Sanitize the environment seen by the buildpack, to prevent reliance on
 # environment variables that won't be present when it's run by Heroku CI.

--- a/bin/compile
+++ b/bin/compile
@@ -18,6 +18,46 @@ mktmpdir() {
   echo $dir
 }
 
+mkcert() {
+  keyout=$1
+  certout=$2
+  cakeyout=$3
+  cacertout=$4
+
+  openssl genrsa -out $cakeyout 4096
+  openssl genrsa -out $keyout 2048
+
+  openssl req \
+    -x509 -new -nodes -sha256 \
+    -subj "/O=Heroku CI/CN=Ceritificate Authority" \
+    -days 3650 \
+    -key "$cakeyout" \
+    -out "$cacertout"
+
+  openssl req \
+    -new -sha256 \
+    -subj "/O=Heroku CI/CN=localhost" \
+    -key "$keyout" | \
+    openssl x509 -req -sha256 \
+      -CA "$cacertout" \
+      -CAkey "$cakeyout" \
+      -CAcreateserial \
+      -days 365 \
+      -out "$certout"
+}
+
+mkredisconf() {
+  cat <<EOF > $1
+port 0
+tls-port 6379
+tls-auth-clients optional
+tls-cert-file $2
+tls-key-file $3
+tls-ca-cert-file $4
+requirepass $5
+EOF
+}
+
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
@@ -33,6 +73,12 @@ else
   VERSION="${DEFAULT_VERSION}"
 fi
 
+if [ -f "${ENV_DIR}/REDIS_CI_TLS" ]; then
+  export REDIS_CI_TLS="$(cat ${ENV_DIR}/REDIS_CI_TLS)"
+fi
+
+SERVICE_MIN_VER="6.2"
+
 case "${VERSION}" in
   3) VERSION="3.2.13";;
   4) VERSION="4.0.14";;
@@ -40,6 +86,13 @@ case "${VERSION}" in
   6|6.2) VERSION="6.2.12";;
   7|7.0) VERSION="7.0.11";;
 esac
+
+if dpkg --compare-versions "$VERSION" "lt" "${SERVICE_MIN_VER}"; then
+  echo "!      Unsupported service version: $VERSION" && \
+  echo "!      Set REDIS_VERSION to $SERVICE_MIN_VER or higher in your app.json" && \
+  echo "!      See https://devcenter.heroku.com/articles/heroku-redis#version-support-and-legacy-infrastructure" && \
+  exit 1
+fi
 
 echo "Using redis version: ${VERSION}" | indent
 
@@ -56,7 +109,7 @@ if [ ! -d "${CACHED_REDIS_DIR}" ]; then
 	curl -OLf "https://download.redis.io/releases/redis-$VERSION.tar.gz"
 	tar zxvf "redis-$VERSION.tar.gz"
 	cd "redis-$VERSION"
-	make
+	make BUILD_TLS=yes
 	make PREFIX="${CACHED_REDIS_DIR}/" install
 	cp -r "${CACHED_REDIS_DIR}"/* "${INSTALL_DIR}/"
 else
@@ -65,24 +118,38 @@ else
 fi
 
 set-env PATH '/app/.indyno/vendor/redis/bin:$PATH'
-PASSWORD=`openssl rand -hex 16`
+PASSWORD=$(openssl rand -hex 32)
 
-# placeholder username h was added for compatibility with old Redis clients (https://devcenter.heroku.com/changelog-items/1932) and is incompatible with Redis 6 AUTH
-if dpkg --compare-versions "$VERSION" "lt" 6; then
-	export REDIS_URL="redis://h:$PASSWORD@localhost:6379/"
-else
-	export REDIS_URL="redis://:$PASSWORD@localhost:6379/"
+SERVER_COMMAND="echo requirepass $PASSWORD | redis-server - &> /dev/null &"
+REDIS_URL="redis://:$PASSWORD@localhost:6379/"
+
+if [ -n "$REDIS_CI_TLS" ]; then
+  REDIS_URL="rediss://:$PASSWORD@localhost:6379/"
+  SERVER_COMMAND="redis-server $INSTALL_DIR/redis.conf &> /dev/null &"
+
+  mkcert \
+    $INSTALL_DIR/server.key \
+    $INSTALL_DIR/server.crt \
+    $INSTALL_DIR/ca.key \
+    $INSTALL_DIR/ca.crt
+
+  mkredisconf \
+    $INSTALL_DIR/redis.conf \
+    $INSTALL_DIR/server.crt \
+    $INSTALL_DIR/server.key \
+    $INSTALL_DIR/ca.crt \
+    $PASSWORD
 fi
 
 set-env REDIS_URL "$REDIS_URL"
 echo "export REDIS_URL=$REDIS_URL" >> $BUILDPACK_DIR/export
-echo "echo requirepass $PASSWORD | redis-server - &> /dev/null &" >> $PROFILE_PATH
+echo "$SERVER_COMMAND" >> $PROFILE_PATH
 
 # ensure the redis-server is started during CI runs as the buildpack runner will terminate redis-server between buildpacks and .profile.d is too late
 cat<<EOF > $BUILDPACK_DIR/background
 PATH=$HOME/.indyno/vendor/redis/bin:$PATH
 export REDIS_URL="$REDIS_URL"
-echo requirepass $PASSWORD | redis-server - &> /dev/null &
+$SERVER_COMMAND
 EOF
 
 echo "-----> Redis done"

--- a/bin/compile
+++ b/bin/compile
@@ -121,10 +121,10 @@ set-env PATH '/app/.indyno/vendor/redis/bin:$PATH'
 PASSWORD=$(openssl rand -hex 32)
 
 SERVER_COMMAND="echo requirepass $PASSWORD | redis-server - &> /dev/null &"
-REDIS_URL="redis://:$PASSWORD@localhost:6379/"
+REDIS_URL="redis://:$PASSWORD@localhost:6379"
 
 if [ -n "$REDIS_CI_TLS" ]; then
-  REDIS_URL="rediss://:$PASSWORD@localhost:6379/"
+  REDIS_URL="rediss://:$PASSWORD@localhost:6379"
   SERVER_COMMAND="redis-server $INSTALL_DIR/redis.conf &> /dev/null &"
 
   mkcert \
@@ -142,6 +142,7 @@ if [ -n "$REDIS_CI_TLS" ]; then
 fi
 
 set-env REDIS_URL "$REDIS_URL"
+set-env REDISCLI_AUTH "$PASSWORD"
 echo "export REDIS_URL=$REDIS_URL" >> $BUILDPACK_DIR/export
 echo "$SERVER_COMMAND" >> $PROFILE_PATH
 

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -29,8 +29,8 @@ fi
 
 # Redis <4 does not support connection URLs so REDIS_URL has to be parsed:
 # https://stackoverflow.com/questions/38271281/can-i-use-redis-cli-with-a-connection-url
-REDIS_CONNECTION_ARGS="\$(echo \${REDIS_URL} | sed 's_rediss\{0,1\}://\(.*\):\(.*\)@\(.*\):\(.*\)/_-h \3 -p \4 -a \2_')"
-TEST_COMMAND="source .profile.d/redis.sh && sleep 1 && redis-cli ${REDIS_TLS_ARGS} ${REDIS_CONNECTION_ARGS} info | grep redis_version:${REDIS_VERSION:-}"
+REDIS_CONNECTION_ARGS="\$(echo \${REDIS_URL} | sed 's_rediss\{0,1\}://\(.*\):\(.*\)@\(.*\):\(.*\)_-h \3 -p \4_')"
+TEST_COMMAND="source .profile.d/redis.sh && sleep 1 && redis-cli ${REDIS_CONNECTION_ARGS} ${REDIS_TLS_ARGS} info | grep redis_version:${REDIS_VERSION:-}"
 docker run --rm -t "${OUTPUT_IMAGE}" bash -c "${TEST_COMMAND}"
 
 echo "Success!"

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -7,21 +7,30 @@ set -euo pipefail
 STACK="${1}"
 BASE_IMAGE="heroku/${STACK/-/:}-build"
 OUTPUT_IMAGE="redis-test-${STACK}"
+REDIS_CI_TLS=${REDIS_CI_TLS:-}
 
 echo "Building buildpack on stack ${STACK}...with redis version ${REDIS_VERSION}"
 
 docker build \
+    --no-cache \
     --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
     ${REDIS_VERSION:+--build-arg "REDIS_VERSION=${REDIS_VERSION}"} \
+    ${REDIS_CI_TLS:+--build-arg "REDIS_CI_TLS=${REDIS_CI_TLS}"} \
     -t "${OUTPUT_IMAGE}" \
     .
 
 echo "Checking redis-server presence and version..."
 
+if [ -n "$REDIS_CI_TLS" ]; then
+    REDIS_TLS_ARGS="--tls --insecure"
+else
+    REDIS_TLS_ARGS=""
+fi
+
 # Redis <4 does not support connection URLs so REDIS_URL has to be parsed:
 # https://stackoverflow.com/questions/38271281/can-i-use-redis-cli-with-a-connection-url
-REDIS_CONNECTION_ARGS="\$(echo \${REDIS_URL} | sed 's_redis://\(.*\):\(.*\)@\(.*\):\(.*\)/_-h \3 -p \4 -a \2_')"
-TEST_COMMAND="source .profile.d/redis.sh && sleep 1 && redis-cli ${REDIS_CONNECTION_ARGS} info | grep redis_version:${REDIS_VERSION:-}"
+REDIS_CONNECTION_ARGS="\$(echo \${REDIS_URL} | sed 's_rediss\{0,1\}://\(.*\):\(.*\)@\(.*\):\(.*\)/_-h \3 -p \4 -a \2_')"
+TEST_COMMAND="source .profile.d/redis.sh && sleep 1 && redis-cli ${REDIS_TLS_ARGS} ${REDIS_CONNECTION_ARGS} info | grep redis_version:${REDIS_VERSION:-}"
 docker run --rm -t "${OUTPUT_IMAGE}" bash -c "${TEST_COMMAND}"
 
 echo "Success!"


### PR DESCRIPTION
This is a pretty huge monster of a change and needs to be split up.

In summary, to align with the Redis Version Support Policy from Heroku, we need to drop all versions < 6.2.

Additionally, we need to support TLS to align with platform standards. This is enabled by passing in `REDIS_CI_TLS` into the environment, which will start a TLS-enabled `redis-server` instead of a plaintext one. This allows for closer parity with production in CI.