### PR TITLE
add v7.2.5

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         stack: [heroku-20, heroku-22, heroku-24]
-        redis_version: ["", "4", "5", "6", "6.2", "7", "7.0", "7.0.11"]
+        redis_version: ["", "4", "5", "6", "6.2", "7", "7.0", "7.0.11", "7.2.5"]
     runs-on: ubuntu-latest
 
     steps:

--- a/bin/compile
+++ b/bin/compile
@@ -39,6 +39,7 @@ case "${VERSION}" in
   5) VERSION="5.0.14";;
   6|6.2) VERSION="6.2.12";;
   7|7.0) VERSION="7.0.11";;
+  7.2|7.2.5) VERSION="7.2.5";;
 esac
 
 echo "Using redis version: ${VERSION}" | indent


### PR DESCRIPTION
Adds the 7.2.5 version, this is the last redis version that is not dual licensed. We'll need to switch to Valkey builds for valkey 8.