### PR TITLE
Test against Heroku-26 in CI

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        stack: [heroku-20, heroku-22, heroku-24]
+        stack: [heroku-22, heroku-24, heroku-26]
         redis_version: ["", "4", "5", "6", "6.2", "7", "7.0", "7.2", "7.0.11"]
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
And stop testing against the EOL Heroku-20.

The buildpack itself didn't need any changes to work with Heroku-26.

GUS-W-20776935.