### PR TITLE
Switch buildpack to Valkey (7.2, 8 default, 9)

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         stack: [heroku-22, heroku-24, heroku-26]
-        valkey_version: ["", "7.2", "8", "8.1", "9", "9.1", "8.1.8"]
+        valkey_version: ["", "7.2", "8", "8.1", "9", "9.1", "7.2.13"]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         stack: [heroku-22, heroku-24, heroku-26]
-        redis_version: ["", "4", "5", "6", "6.2", "7", "7.0", "7.2", "7.0.11"]
+        valkey_version: ["", "7.2", "8", "8.1", "9", "9.1", "8.1.8"]
     runs-on: ubuntu-latest
 
     steps:
@@ -16,7 +16,7 @@ jobs:
     - name: Run Test
       run: ./bin/test.sh ${{ matrix.stack }}
       env:
-        REDIS_VERSION: ${{ matrix.redis_version }}
+        VALKEY_VERSION: ${{ matrix.valkey_version }}
 
   # dummy job to wait and block merge until all jobs have completed
   done:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ ARG BASE_IMAGE
 FROM $BASE_IMAGE
 USER root
 
-ARG REDIS_VERSION
+ARG VALKEY_VERSION
 
 RUN mkdir -p /app /cache /env
-RUN [ -z "${REDIS_VERSION}" ] || echo "${REDIS_VERSION}" > /env/REDIS_VERSION
+RUN [ -z "${VALKEY_VERSION}" ] || echo "${VALKEY_VERSION}" > /env/VALKEY_VERSION
 COPY . /buildpack
 # Sanitize the environment seen by the buildpack, to prevent reliance on
 # environment variables that won't be present when it's run by Heroku CI.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Heroku CI or any other environment where data retention is not important.
 Please note that Valkey will lose all data each time a dyno restarts.
 
 Valkey is a drop-in replacement for Redis and speaks the same protocol, so the
-connection URL is exposed as both `VALKEY_URL` and `REDIS_URL`.
+connection URL is exposed as both `VALKEY_URL` and `REDIS_URL`. On Valkey 9 the
+`VALKEY_URL` authenticates as the `heroku` ACL user; `REDIS_URL` always uses the
+default user, so either variable works.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Heroku CI or any other environment where data retention is not important.
 Please note that Valkey will lose all data each time a dyno restarts.
 
 Valkey is a drop-in replacement for Redis and speaks the same protocol, so the
-connection URL is exposed as both `VALKEY_URL` and `REDIS_URL`. On Valkey 9 the
-`VALKEY_URL` authenticates as the `heroku` ACL user; `REDIS_URL` always uses the
-default user, so either variable works.
+connection URL is exposed as both `VALKEY_URL` and `REDIS_URL`, which are always
+identical. On Valkey 9 both authenticate as the `heroku` ACL user; on earlier
+versions both use the default user.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,31 @@
 **Warning** this is an experimental buildpack and is provided as-is without any
 promise of support.
 
-# Heroku CI buildpack: Redis
+# Heroku CI buildpack: Valkey
 
 This experimental [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks)
-vendors Redis into the dyno. It is intended for use with Heroku CI or any
-other environment where data retention is not important.
+vendors [Valkey](https://valkey.io/) into the dyno. It is intended for use with
+Heroku CI or any other environment where data retention is not important.
 
-Please note that Redis will loose all data each time a dyno restarts.
+Please note that Valkey will lose all data each time a dyno restarts.
+
+Valkey is a drop-in replacement for Redis and speaks the same protocol, so the
+connection URL is exposed as both `VALKEY_URL` and `REDIS_URL`.
 
 ## Usage
 
-The first run of this buildpack will take a while as Redis is downloaded and
-compiled. Thereafter the compiled version will be cached. Redis will start locally
-and be available on `redis://127.0.0.1:6379` available in the `REDIS_URL` environment variable.
+The first run of this buildpack will take a while as Valkey is downloaded and
+compiled. Thereafter the compiled version will be cached. Valkey will start
+locally on `redis://127.0.0.1:6379`, available in both the `VALKEY_URL` and
+`REDIS_URL` environment variables.
 
-By default Redis 7 is used, however you can specify a `REDIS_VERSION` in the `env` section of your
+By default Valkey 8 is used. You can specify a `VALKEY_VERSION` in the `env`
+section of your
 [app.json](https://devcenter.heroku.com/articles/heroku-ci#environment-variables-env-key)
-to use a different major (e.g. "4" or "5") or exact (e.g. "6.0.16") version. This feature
-is experimental and subject to change.
+to select a supported major (`7.2`, `8`, or `9`) or an exact version (e.g.
+`8.1.8`). For backward compatibility, `REDIS_VERSION` is also honored when
+`VALKEY_VERSION` is not set. Versions older than 7.2 are no longer supported and
+fall back to 7.2. This feature is experimental and subject to change.
 
 ## Releasing a new version
 

--- a/bin/compile
+++ b/bin/compile
@@ -29,7 +29,7 @@ PROFILE_PATH="$BUILD_DIR/.profile.d/valkey.sh"
 # Supported Valkey versions, oldest first. Single source of truth: the default,
 # the aliases (major like "8" or major.minor like "8.1"), and the oldest-supported
 # fallback are all derived from this list. To change support, edit only this line.
-SUPPORTED_VERSIONS=(7.2.13 8.1.8 9.1.0)
+SUPPORTED_VERSIONS=(7.2.14 8.1.9 9.1.1)
 DEFAULT_VERSION="8"
 OLDEST_VERSION="${SUPPORTED_VERSIONS[0]}"
 

--- a/bin/compile
+++ b/bin/compile
@@ -43,6 +43,8 @@ esac
 
 # Redis-era versions (< 7.2) are no longer supported; remap to the oldest
 # supported Valkey so existing customers don't hit unexpected failures.
+# Relies on dpkg, which is present on all Heroku stacks; bogus input (e.g.
+# "banana") fails the comparison and passes through to a 404 at download.
 if dpkg --compare-versions "$VERSION" lt "7.2" 2>/dev/null; then
   echo "WARNING: version ${VERSION} is unsupported; using oldest supported Valkey 7.2.13" | indent
   VERSION="7.2.13"

--- a/bin/compile
+++ b/bin/compile
@@ -87,14 +87,25 @@ fi
 set-env PATH '/app/.indyno/vendor/valkey/bin:$PATH'
 PASSWORD=`openssl rand -hex 16`
 
-VALKEY_URL="redis://:$PASSWORD@localhost:6379/"
-REDIS_URL="$VALKEY_URL"
+# Valkey 9 ships with a "heroku" ACL user. Create it alongside the default user
+# (kept via requirepass) so both the legacy REDIS_URL (default user) and the
+# VALKEY_URL (heroku user) authenticate. Earlier versions have no such user.
+if dpkg --compare-versions "$VERSION" ge "9" 2>/dev/null; then
+  # `reset` first so our grant is deterministic regardless of the built-in
+  # heroku user's default ACL rules (user directives merge, they don't replace).
+  START_CMD="printf 'requirepass %s\nuser heroku reset on >%s ~* &* +@all\n' '$PASSWORD' '$PASSWORD' | valkey-server - &> /dev/null &"
+  VALKEY_URL="redis://heroku:$PASSWORD@localhost:6379/"
+else
+  START_CMD="echo requirepass $PASSWORD | valkey-server - &> /dev/null &"
+  VALKEY_URL="redis://:$PASSWORD@localhost:6379/"
+fi
+REDIS_URL="redis://:$PASSWORD@localhost:6379/"
 
 set-env REDIS_URL "$REDIS_URL"
 set-env VALKEY_URL "$VALKEY_URL"
 echo "export REDIS_URL=$REDIS_URL" >> $BUILDPACK_DIR/export
 echo "export VALKEY_URL=$VALKEY_URL" >> $BUILDPACK_DIR/export
-echo "echo requirepass $PASSWORD | valkey-server - &> /dev/null &" >> $PROFILE_PATH
+printf '%s\n' "$START_CMD" >> $PROFILE_PATH
 
 # ensure valkey-server is started during CI runs as the buildpack runner will
 # terminate it between buildpacks and .profile.d is too late
@@ -102,7 +113,7 @@ cat<<EOF > $BUILDPACK_DIR/background
 PATH=$HOME/.indyno/vendor/valkey/bin:$PATH
 export REDIS_URL="$REDIS_URL"
 export VALKEY_URL="$VALKEY_URL"
-echo requirepass $PASSWORD | valkey-server - &> /dev/null &
+$START_CMD
 EOF
 
 echo "-----> Valkey done"

--- a/bin/compile
+++ b/bin/compile
@@ -87,19 +87,20 @@ fi
 set-env PATH '/app/.indyno/vendor/valkey/bin:$PATH'
 PASSWORD=`openssl rand -hex 16`
 
-# Valkey 9 ships with a "heroku" ACL user. Create it alongside the default user
-# (kept via requirepass) so both the legacy REDIS_URL (default user) and the
-# VALKEY_URL (heroku user) authenticate. Earlier versions have no such user.
+# Valkey 9 ships with a "heroku" ACL user. Create it (the default user stays
+# enabled via requirepass) and connect as it. Earlier versions have no such
+# user and connect as the default user. Both URLs are identical either way.
 if dpkg --compare-versions "$VERSION" ge "9" 2>/dev/null; then
   # `reset` first so our grant is deterministic regardless of the built-in
   # heroku user's default ACL rules (user directives merge, they don't replace).
   START_CMD="printf 'requirepass %s\nuser heroku reset on >%s ~* &* +@all\n' '$PASSWORD' '$PASSWORD' | valkey-server - &> /dev/null &"
-  VALKEY_URL="redis://heroku:$PASSWORD@localhost:6379/"
+  URL="redis://heroku:$PASSWORD@localhost:6379/"
 else
   START_CMD="echo requirepass $PASSWORD | valkey-server - &> /dev/null &"
-  VALKEY_URL="redis://:$PASSWORD@localhost:6379/"
+  URL="redis://:$PASSWORD@localhost:6379/"
 fi
-REDIS_URL="redis://:$PASSWORD@localhost:6379/"
+VALKEY_URL="$URL"
+REDIS_URL="$URL"
 
 set-env REDIS_URL "$REDIS_URL"
 set-env VALKEY_URL "$VALKEY_URL"

--- a/bin/compile
+++ b/bin/compile
@@ -26,7 +26,13 @@ VALKEY_BUILD="$(mktmpdir valkey)"
 INSTALL_DIR="$BUILD_DIR/.indyno/vendor/valkey"
 PROFILE_PATH="$BUILD_DIR/.profile.d/valkey.sh"
 
+# Supported Valkey versions, oldest first. Single source of truth: the default,
+# the aliases (major like "8" or major.minor like "8.1"), and the oldest-supported
+# fallback are all derived from this list. To change support, edit only this line.
+SUPPORTED_VERSIONS=(7.2.13 8.1.8 9.1.0)
 DEFAULT_VERSION="8"
+OLDEST_VERSION="${SUPPORTED_VERSIONS[0]}"
+
 if [ -f "${ENV_DIR}/VALKEY_VERSION" ]; then
   VERSION="$(cat ${ENV_DIR}/VALKEY_VERSION)"
 elif [ -f "${ENV_DIR}/REDIS_VERSION" ]; then
@@ -35,19 +41,24 @@ else
   VERSION="${DEFAULT_VERSION}"
 fi
 
-case "${VERSION}" in
-  7.2) VERSION="7.2.13";;
-  8|8.1) VERSION="8.1.8";;
-  9|9.1) VERSION="9.1.0";;
-esac
+# Resolve an alias (major or major.minor) or exact version to a supported pin,
+# preferring the newest match.
+resolved=""
+for v in "${SUPPORTED_VERSIONS[@]}"; do
+  case "${VERSION}" in
+    "$v"|"${v%.*}"|"${v%%.*}") resolved="$v";;
+  esac
+done
 
-# Redis-era versions (< 7.2) are no longer supported; remap to the oldest
-# supported Valkey so existing customers don't hit unexpected failures.
-# Relies on dpkg, which is present on all Heroku stacks; bogus input (e.g.
-# "banana") fails the comparison and passes through to a 404 at download.
-if dpkg --compare-versions "$VERSION" lt "7.2" 2>/dev/null; then
-  echo "WARNING: version ${VERSION} is unsupported; using oldest supported Valkey 7.2.13" | indent
-  VERSION="7.2.13"
+if [ -n "${resolved}" ]; then
+  VERSION="${resolved}"
+# Versions older than the oldest supported line (e.g. Redis-era 6.x) remap to
+# the oldest supported Valkey so existing customers don't hit unexpected
+# failures. dpkg is present on all Heroku stacks; bogus input (e.g. "banana")
+# fails the comparison and passes through to a 404 at download.
+elif dpkg --compare-versions "${VERSION}" lt "${OLDEST_VERSION%.*}" 2>/dev/null; then
+  echo "WARNING: version ${VERSION} is unsupported; using oldest supported Valkey ${OLDEST_VERSION}" | indent
+  VERSION="${OLDEST_VERSION}"
 fi
 
 echo "Using valkey version: ${VERSION}" | indent

--- a/bin/compile
+++ b/bin/compile
@@ -97,10 +97,7 @@ if dpkg --compare-versions "$VERSION" ge "9" 2>/dev/null; then
   URL="redis://heroku:$PASSWORD@localhost:6379/"
 else
   START_CMD="echo requirepass $PASSWORD | valkey-server - &> /dev/null &"
-  # Name the built-in "default" user explicitly. An empty username
-  # (redis://:pw@) makes valkey-cli send AUTH "" pw, which the server rejects
-  # with WRONGPASS; "default" works for both valkey-cli and client libraries.
-  URL="redis://default:$PASSWORD@localhost:6379/"
+  URL="redis://:$PASSWORD@localhost:6379/"
 fi
 VALKEY_URL="$URL"
 REDIS_URL="$URL"

--- a/bin/compile
+++ b/bin/compile
@@ -22,68 +22,74 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
 BUILDPACK_DIR="$(dirname $(dirname $0))"
-REDIS_BUILD="$(mktmpdir redis)"
-INSTALL_DIR="$BUILD_DIR/.indyno/vendor/redis"
-PROFILE_PATH="$BUILD_DIR/.profile.d/redis.sh"
+VALKEY_BUILD="$(mktmpdir valkey)"
+INSTALL_DIR="$BUILD_DIR/.indyno/vendor/valkey"
+PROFILE_PATH="$BUILD_DIR/.profile.d/valkey.sh"
 
-DEFAULT_VERSION="7"
-if [ -f "${ENV_DIR}/REDIS_VERSION" ]; then
+DEFAULT_VERSION="8"
+if [ -f "${ENV_DIR}/VALKEY_VERSION" ]; then
+  VERSION="$(cat ${ENV_DIR}/VALKEY_VERSION)"
+elif [ -f "${ENV_DIR}/REDIS_VERSION" ]; then
   VERSION="$(cat ${ENV_DIR}/REDIS_VERSION)"
 else
   VERSION="${DEFAULT_VERSION}"
 fi
 
 case "${VERSION}" in
-  3) VERSION="3.2.13";;
-  4) VERSION="4.0.14";;
-  5) VERSION="5.0.14";;
-  6|6.2) VERSION="6.2.12";;
-  7|7.0) VERSION="7.0.11";;
-  7.2) VERSION="7.2.5";;
+  7.2) VERSION="7.2.13";;
+  8|8.1) VERSION="8.1.8";;
+  9|9.1) VERSION="9.1.0";;
 esac
 
-echo "Using redis version: ${VERSION}" | indent
+# Redis-era versions (< 7.2) are no longer supported; remap to the oldest
+# supported Valkey so existing customers don't hit unexpected failures.
+if dpkg --compare-versions "$VERSION" lt "7.2" 2>/dev/null; then
+  echo "WARNING: version ${VERSION} is unsupported; using oldest supported Valkey 7.2.13" | indent
+  VERSION="7.2.13"
+fi
+
+echo "Using valkey version: ${VERSION}" | indent
 
 mkdir -p $INSTALL_DIR
 mkdir -p $(dirname $PROFILE_PATH)
 mkdir -p $CACHE_DIR
 
-CACHED_REDIS_DIR="${CACHE_DIR}/redis_${STACK}_${VERSION}"
+CACHED_VALKEY_DIR="${CACHE_DIR}/valkey_${STACK}_${VERSION}"
 
-if [ ! -d "${CACHED_REDIS_DIR}" ]; then
-	echo "-----> Downloading and installing redis into slug"
-	rm -rf "${CACHE_DIR}"/redis_*
-	cd $REDIS_BUILD
-	curl -OLf "https://download.redis.io/releases/redis-$VERSION.tar.gz"
-	tar zxvf "redis-$VERSION.tar.gz"
-	cd "redis-$VERSION"
+if [ ! -d "${CACHED_VALKEY_DIR}" ]; then
+	echo "-----> Downloading and installing valkey into slug"
+	rm -rf "${CACHE_DIR}"/valkey_*
+	cd $VALKEY_BUILD
+	curl -OLf "https://github.com/valkey-io/valkey/archive/refs/tags/${VERSION}.tar.gz"
+	tar zxvf "${VERSION}.tar.gz"
+	cd "valkey-${VERSION}"
 	make
-	make PREFIX="${CACHED_REDIS_DIR}/" install
-	cp -r "${CACHED_REDIS_DIR}"/* "${INSTALL_DIR}/"
+	make PREFIX="${CACHED_VALKEY_DIR}/" install
+	cp -r "${CACHED_VALKEY_DIR}"/* "${INSTALL_DIR}/"
 else
-	echo "-----> Fetching redis from cache into slug"
-	cp -r "${CACHED_REDIS_DIR}"/* "${INSTALL_DIR}/"
+	echo "-----> Fetching valkey from cache into slug"
+	cp -r "${CACHED_VALKEY_DIR}"/* "${INSTALL_DIR}/"
 fi
 
-set-env PATH '/app/.indyno/vendor/redis/bin:$PATH'
+set-env PATH '/app/.indyno/vendor/valkey/bin:$PATH'
 PASSWORD=`openssl rand -hex 16`
 
-# placeholder username h was added for compatibility with old Redis clients (https://devcenter.heroku.com/changelog-items/1932) and is incompatible with Redis 6 AUTH
-if dpkg --compare-versions "$VERSION" "lt" 6; then
-	export REDIS_URL="redis://h:$PASSWORD@localhost:6379/"
-else
-	export REDIS_URL="redis://:$PASSWORD@localhost:6379/"
-fi
+VALKEY_URL="redis://:$PASSWORD@localhost:6379/"
+REDIS_URL="$VALKEY_URL"
 
 set-env REDIS_URL "$REDIS_URL"
+set-env VALKEY_URL "$VALKEY_URL"
 echo "export REDIS_URL=$REDIS_URL" >> $BUILDPACK_DIR/export
-echo "echo requirepass $PASSWORD | redis-server - &> /dev/null &" >> $PROFILE_PATH
+echo "export VALKEY_URL=$VALKEY_URL" >> $BUILDPACK_DIR/export
+echo "echo requirepass $PASSWORD | valkey-server - &> /dev/null &" >> $PROFILE_PATH
 
-# ensure the redis-server is started during CI runs as the buildpack runner will terminate redis-server between buildpacks and .profile.d is too late
+# ensure valkey-server is started during CI runs as the buildpack runner will
+# terminate it between buildpacks and .profile.d is too late
 cat<<EOF > $BUILDPACK_DIR/background
-PATH=$HOME/.indyno/vendor/redis/bin:$PATH
+PATH=$HOME/.indyno/vendor/valkey/bin:$PATH
 export REDIS_URL="$REDIS_URL"
-echo requirepass $PASSWORD | redis-server - &> /dev/null &
+export VALKEY_URL="$VALKEY_URL"
+echo requirepass $PASSWORD | valkey-server - &> /dev/null &
 EOF
 
-echo "-----> Redis done"
+echo "-----> Valkey done"

--- a/bin/compile
+++ b/bin/compile
@@ -97,7 +97,10 @@ if dpkg --compare-versions "$VERSION" ge "9" 2>/dev/null; then
   URL="redis://heroku:$PASSWORD@localhost:6379/"
 else
   START_CMD="echo requirepass $PASSWORD | valkey-server - &> /dev/null &"
-  URL="redis://:$PASSWORD@localhost:6379/"
+  # Name the built-in "default" user explicitly. An empty username
+  # (redis://:pw@) makes valkey-cli send AUTH "" pw, which the server rejects
+  # with WRONGPASS; "default" works for both valkey-cli and client libraries.
+  URL="redis://default:$PASSWORD@localhost:6379/"
 fi
 VALKEY_URL="$URL"
 REDIS_URL="$URL"

--- a/bin/detect
+++ b/bin/detect
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
-echo "Redis"
+echo "Valkey"

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -19,9 +19,9 @@ docker build \
 echo "Checking valkey-server presence and version..."
 
 # Valkey's INFO reports a fixed compatibility redis_version; the real version
-# is in the valkey_version field, so assert against that.
-VALKEY_CONNECTION_ARGS="\$(echo \${VALKEY_URL} | sed 's_redis://:\([^@]*\)@\([^:]*\):\([^/]*\)/_-h \2 -p \3 -a \1_')"
-TEST_COMMAND="source .profile.d/valkey.sh && sleep 1 && valkey-cli ${VALKEY_CONNECTION_ARGS} info | grep valkey_version:${VALKEY_VERSION:-}"
+# is in the valkey_version field, so assert against that. valkey-cli -u parses
+# the URL directly, so it works whether or not VALKEY_URL carries a username.
+TEST_COMMAND="source .profile.d/valkey.sh && sleep 1 && valkey-cli -u \"\${VALKEY_URL}\" info | grep valkey_version:${VALKEY_VERSION:-}"
 docker run --rm -t "${OUTPUT_IMAGE}" bash -c "${TEST_COMMAND}"
 
 echo "Success!"

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -20,7 +20,7 @@ echo "Checking valkey-server presence and version..."
 
 # Valkey's INFO reports a fixed compatibility redis_version; the real version
 # is in the valkey_version field, so assert against that.
-VALKEY_CONNECTION_ARGS="\$(echo \${VALKEY_URL} | sed 's_redis://:\(.*\)@\(.*\):\(.*\)/_-h \2 -p \3 -a \1_')"
+VALKEY_CONNECTION_ARGS="\$(echo \${VALKEY_URL} | sed 's_redis://:\([^@]*\)@\([^:]*\):\([^/]*\)/_-h \2 -p \3 -a \1_')"
 TEST_COMMAND="source .profile.d/valkey.sh && sleep 1 && valkey-cli ${VALKEY_CONNECTION_ARGS} info | grep valkey_version:${VALKEY_VERSION:-}"
 docker run --rm -t "${OUTPUT_IMAGE}" bash -c "${TEST_COMMAND}"
 

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -19,13 +19,16 @@ docker build \
 echo "Checking valkey-server presence and version..."
 
 # Valkey's INFO reports a fixed compatibility redis_version; the real version
-# is in the valkey_version field, so assert against that. valkey-cli -u parses
-# the URL directly, so it works whether or not the URL carries a username.
-# Both URLs are checked: on Valkey 9 they authenticate as different users
-# (VALKEY_URL as heroku, REDIS_URL as the default user).
-TEST_COMMAND="source .profile.d/valkey.sh && sleep 1 \
-  && valkey-cli -u \"\${VALKEY_URL}\" info | grep valkey_version:${VALKEY_VERSION:-} \
-  && valkey-cli -u \"\${REDIS_URL}\" info | grep valkey_version:${VALKEY_VERSION:-}"
+# is in the valkey_version field, so assert against that. The URLs carry an
+# empty username (redis://:pw@) to match Heroku Key-Value Store, but
+# valkey-cli -u would then send AUTH "" pw and fail, so extract the user and
+# password and pass them as flags: --user only when the URL names one (v9's
+# heroku ACL user), -a always. Both URLs are checked.
+CHECK='check() { url="$1"; user="${url#*://}"; user="${user%%:*}"; pw="${url%%@*}"; pw="${pw##*:}"; \
+  valkey-cli ${user:+--user "$user"} -a "$pw" info; }'
+TEST_COMMAND="source .profile.d/valkey.sh && sleep 1 && ${CHECK} \
+  && check \"\${VALKEY_URL}\" | grep valkey_version:${VALKEY_VERSION:-} \
+  && check \"\${REDIS_URL}\" | grep valkey_version:${VALKEY_VERSION:-}"
 docker run --rm -t "${OUTPUT_IMAGE}" bash -c "${TEST_COMMAND}"
 
 echo "Success!"

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -6,22 +6,22 @@ set -euo pipefail
 
 STACK="${1}"
 BASE_IMAGE="heroku/${STACK/-/:}-build"
-OUTPUT_IMAGE="redis-test-${STACK}"
+OUTPUT_IMAGE="valkey-test-${STACK}"
 
-echo "Building buildpack on stack ${STACK}...with redis version ${REDIS_VERSION}"
+echo "Building buildpack on stack ${STACK}...with valkey version ${VALKEY_VERSION:-default}"
 
 docker build \
     --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
-    ${REDIS_VERSION:+--build-arg "REDIS_VERSION=${REDIS_VERSION}"} \
+    ${VALKEY_VERSION:+--build-arg "VALKEY_VERSION=${VALKEY_VERSION}"} \
     -t "${OUTPUT_IMAGE}" \
     .
 
-echo "Checking redis-server presence and version..."
+echo "Checking valkey-server presence and version..."
 
-# Redis <4 does not support connection URLs so REDIS_URL has to be parsed:
-# https://stackoverflow.com/questions/38271281/can-i-use-redis-cli-with-a-connection-url
-REDIS_CONNECTION_ARGS="\$(echo \${REDIS_URL} | sed 's_redis://\(.*\):\(.*\)@\(.*\):\(.*\)/_-h \3 -p \4 -a \2_')"
-TEST_COMMAND="source .profile.d/redis.sh && sleep 1 && redis-cli ${REDIS_CONNECTION_ARGS} info | grep redis_version:${REDIS_VERSION:-}"
+# Valkey's INFO reports a fixed compatibility redis_version; the real version
+# is in the valkey_version field, so assert against that.
+VALKEY_CONNECTION_ARGS="\$(echo \${VALKEY_URL} | sed 's_redis://:\(.*\)@\(.*\):\(.*\)/_-h \2 -p \3 -a \1_')"
+TEST_COMMAND="source .profile.d/valkey.sh && sleep 1 && valkey-cli ${VALKEY_CONNECTION_ARGS} info | grep valkey_version:${VALKEY_VERSION:-}"
 docker run --rm -t "${OUTPUT_IMAGE}" bash -c "${TEST_COMMAND}"
 
 echo "Success!"

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -20,8 +20,12 @@ echo "Checking valkey-server presence and version..."
 
 # Valkey's INFO reports a fixed compatibility redis_version; the real version
 # is in the valkey_version field, so assert against that. valkey-cli -u parses
-# the URL directly, so it works whether or not VALKEY_URL carries a username.
-TEST_COMMAND="source .profile.d/valkey.sh && sleep 1 && valkey-cli -u \"\${VALKEY_URL}\" info | grep valkey_version:${VALKEY_VERSION:-}"
+# the URL directly, so it works whether or not the URL carries a username.
+# Both URLs are checked: on Valkey 9 they authenticate as different users
+# (VALKEY_URL as heroku, REDIS_URL as the default user).
+TEST_COMMAND="source .profile.d/valkey.sh && sleep 1 \
+  && valkey-cli -u \"\${VALKEY_URL}\" info | grep valkey_version:${VALKEY_VERSION:-} \
+  && valkey-cli -u \"\${REDIS_URL}\" info | grep valkey_version:${VALKEY_VERSION:-}"
 docker run --rm -t "${OUTPUT_IMAGE}" bash -c "${TEST_COMMAND}"
 
 echo "Success!"


### PR DESCRIPTION
## What

Converts this Heroku CI buildpack from vendoring Redis to vendoring [Valkey](https://valkey.io/). Offers Valkey **7.2**, **8** (the new default), and **9**. Follows through on the plan noted in #41 ("We'll need to switch to Valkey builds for valkey 8").

## Why

The fleet (Shogun) has moved to Valkey 8, with 9.1 now GA. Redis 7.2 was the last non–dual-licensed Redis release; Valkey is the drop-in successor and speaks the same protocol on the same port.

## Changes

- **`bin/compile`**: version precedence `VALKEY_VERSION` → `REDIS_VERSION` → default (`8`); aliases `7.2`→`7.2.13`, `8`/`8.1`→`8.1.8`, `9`/`9.1`→`9.1.0`. Versions `< 7.2` remap to `7.2.13` with a warning so existing customers don't hit unexpected failures; other unknown values fail hard at download as before. Downloads the Valkey source tarball from GitHub and compiles it (Valkey ships source only). Starts `valkey-server` and exports both `VALKEY_URL` and `REDIS_URL`. Removes the obsolete Redis-<6 `h:` username branch.
- **`bin/detect`**: reports `Valkey`.
- **`Dockerfile` / `bin/test.sh`**: `VALKEY_VERSION` build arg; connects with `valkey-cli` and asserts the `valkey_version:` field from `INFO` (Valkey reports a fixed compatibility `redis_version`, so the old assertion no longer tracks the real version).
- **`.github/workflows/config.yml`**: matrix now `valkey_version: ["", "7.2", "8", "8.1", "9", "9.1", "8.1.8"]` across heroku-22/24/26.
- **`README.md`**: documents Valkey, both env vars, and the supported versions.

## Backward compatibility

- `REDIS_URL` is still exported (identical to `VALKEY_URL`).
- `REDIS_VERSION` is still honored when `VALKEY_VERSION` is unset.
- Buildpack registry slug remains `heroku/ci-redis`.

## Testing

Per repo precedent for version changes (#37, #42, #50), verification is the GitHub Actions matrix building and booting each version on each stack via `bin/test.sh`. No local Docker runs.